### PR TITLE
Ignore /data directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,12 +19,17 @@ packages/*/dist/
 
 # Scraped / generated import artifacts (reproducible via scrape scripts)
 /data/imports/html_cache/
-/data/imports/manuscripts/**
+/data/imports/manuscripts/
 /data/imports/*.tsv
 /data/imports/full_torah_checkpoint.json
 /data/imports/torah_scrape_manifest.json
-/docs/import-runs/**
+/docs/import-runs/
 /book_sources/
+/data/imports/manuscripts/crops/
+/data/imports/manuscripts/*/raw-pages/
+/data/imports/manuscripts/*/thumbnails/
+/data/imports/manuscripts/*/runs/
+/docs/import-runs/
 
 # Environment
 .env

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ packages/*/dist/
 *.tsbuildinfo
 
 # Local data
+/data
 /data/app.db
 /data/exports/
 /data/verses/
@@ -18,17 +19,12 @@ packages/*/dist/
 
 # Scraped / generated import artifacts (reproducible via scrape scripts)
 /data/imports/html_cache/
-/data/imports/manuscripts/
+/data/imports/manuscripts/**
 /data/imports/*.tsv
 /data/imports/full_torah_checkpoint.json
 /data/imports/torah_scrape_manifest.json
-/docs/import-runs/
+/docs/import-runs/**
 /book_sources/
-/data/imports/manuscripts/crops/
-/data/imports/manuscripts/*/raw-pages/
-/data/imports/manuscripts/*/thumbnails/
-/data/imports/manuscripts/*/runs/
-/docs/import-runs/
 
 # Environment
 .env


### PR DESCRIPTION
## Linked Issues
- Parent Epic: #
- Child Issue: #

## Scope
- Add `/data` to `.gitignore` so the top-level data directory is ignored.

## Acceptance Criteria Checklist
- [x] Criterion 1: Top-level `/data` path is ignored by git.
- [x] Criterion 2: Existing `.gitignore` patterns remain unchanged.
- [x] Criterion 3: PR diff is limited to `.gitignore`.

## Migration / Data Notes
- Schema changes: none.
- Backfill/migration behavior: none.
- Rollback notes: remove `/data` line from `.gitignore`.

## Test Evidence
- [ ] `pnpm typecheck` (CI)
- [ ] `pnpm test` (CI)
- [x] Targeted tests: `git diff origin/main...HEAD -- .gitignore` shows only `/data` addition.
- [x] Manual validation notes: reviewed `.gitignore` and PR file diff.
