### PR TITLE
Add snippet remap, taam alignment pipeline, and monitoring dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,15 @@ Manuscript exports/review:
 - `GET /api/manuscripts/export/confidence`
 - `GET /api/manuscripts/export/diffs`
 - `GET /api/manuscripts/jobs/ocr`
+- `POST /api/manuscripts/retag/remap`
+- `POST /api/manuscripts/taamim/align/run`
+- `POST /api/manuscripts/taamim/cascade/recompute`
+- `GET /api/manuscripts/verse/:verseId/taamim/witnesses`
+- `GET /api/manuscripts/verse/:verseId/taamim/consensus`
+- `POST /api/manuscripts/verse/:verseId/taamim/apply-consensus`
+- `GET /api/manuscripts/monitoring/summary`
+- `GET /api/manuscripts/monitoring/jobs`
+- `GET /api/manuscripts/monitoring/system`
 
 When signed out, mutation routes return `401`. Patch entries are attributed to Clerk username (fallback to email local-part, then user-id prefix).
 
@@ -171,3 +180,4 @@ Runbooks:
 
 - `docs/issue-1-mac-mini-uptime.md`
 - `docs/next-steps-issue2.md`
+- `docs/m1-8gb-runtime-profile.md`

--- a/apps/web/app/api/manuscripts/monitoring/jobs/route.ts
+++ b/apps/web/app/api/manuscripts/monitoring/jobs/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from "next/server";
+import { getRepository } from "@/lib/repository";
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const status = searchParams.get("status")?.trim() as "queued" | "running" | "completed" | "failed" | null;
+  const limit = Math.max(1, Math.min(500, Number(searchParams.get("limit") ?? 200)));
+  const repo = getRepository();
+  const ocr = repo.listOcrJobs(status ?? undefined).slice(0, limit);
+  const taam = repo.listTaamAlignmentJobs(status ?? undefined).slice(0, limit);
+  return NextResponse.json({ ocr, taam });
+}

--- a/apps/web/app/api/manuscripts/monitoring/summary/route.ts
+++ b/apps/web/app/api/manuscripts/monitoring/summary/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+import { getRepository } from "@/lib/repository";
+
+export async function GET() {
+  const repo = getRepository();
+  const witnesses = repo.getManuscriptOpsSnapshot();
+  const taamJobs = repo.listTaamAlignmentJobs();
+  const reviewQueueLow = repo.listTextReviewQueue("low_confidence").length;
+  const reviewQueueDisagreement = repo.listTextReviewQueue("disagreement").length;
+  const reviewQueueUnavailable = repo.listTextReviewQueue("unavailable_partial").length;
+  const remapAmbiguous = witnesses.reduce((sum, row) => {
+    const regions = repo.listRegionsByWitness(row.witnessId);
+    return sum + regions.filter((region) => region.remapReviewRequired).length;
+  }, 0);
+
+  return NextResponse.json({
+    generatedAt: new Date().toISOString(),
+    witnesses,
+    queues: {
+      textLowConfidence: reviewQueueLow,
+      textDisagreement: reviewQueueDisagreement,
+      textUnavailablePartial: reviewQueueUnavailable,
+      remapAmbiguous,
+    },
+    jobs: {
+      taamQueued: taamJobs.filter((job) => job.status === "queued").length,
+      taamRunning: taamJobs.filter((job) => job.status === "running").length,
+      taamFailed: taamJobs.filter((job) => job.status === "failed").length,
+      taamCompleted: taamJobs.filter((job) => job.status === "completed").length,
+    },
+  });
+}

--- a/apps/web/app/api/manuscripts/monitoring/system/route.ts
+++ b/apps/web/app/api/manuscripts/monitoring/system/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from "next/server";
+import { getSystemTelemetry } from "@/lib/manuscripts-pipeline";
+
+export async function GET() {
+  const telemetry = getSystemTelemetry();
+  return NextResponse.json({ generatedAt: new Date().toISOString(), telemetry });
+}

--- a/apps/web/app/api/manuscripts/retag/remap/route.ts
+++ b/apps/web/app/api/manuscripts/retag/remap/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+import { authErrorResponse, requireEditorUser } from "@/lib/authz";
+import { backfillWitnessFromRemap, remapWitnessRegionsBySnippet } from "@/lib/manuscripts-pipeline";
+
+export async function POST(request: Request) {
+  try {
+    await requireEditorUser();
+  } catch (error) {
+    return authErrorResponse(error) ?? NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const payload = (await request.json().catch(() => ({}))) as Record<string, unknown>;
+  const witnessId = String(payload.witnessId ?? "").trim();
+  if (!witnessId) return NextResponse.json({ error: "witnessId is required." }, { status: 400 });
+
+  const minScore = Number(payload.minScore ?? 0.78);
+  const minMargin = Number(payload.minMargin ?? 0.08);
+  const maxWindow = Number(payload.maxWindow ?? 5);
+  const runBackfill = Boolean(payload.runBackfill ?? true);
+
+  try {
+    const remap = await remapWitnessRegionsBySnippet({ witnessId, minScore, minMargin, maxWindow });
+    const backfill = runBackfill ? await backfillWitnessFromRemap(witnessId) : null;
+    return NextResponse.json({ ok: true, remap, backfill });
+  } catch (error) {
+    return NextResponse.json({ error: error instanceof Error ? error.message : "Remap failed." }, { status: 400 });
+  }
+}

--- a/apps/web/app/api/manuscripts/taamim/align/run/route.ts
+++ b/apps/web/app/api/manuscripts/taamim/align/run/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from "next/server";
+import { authErrorResponse, requireEditorUser } from "@/lib/authz";
+import { getRepository } from "@/lib/repository";
+import { runTaamAlignmentForVerse } from "@/lib/manuscripts-pipeline";
+
+export async function POST(request: Request) {
+  try {
+    await requireEditorUser();
+  } catch (error) {
+    return authErrorResponse(error) ?? NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const payload = (await request.json().catch(() => ({}))) as Record<string, unknown>;
+  const targetLayer = String(payload.targetLayer ?? "working_text");
+  const verseId = String(payload.verseId ?? "").trim();
+  const witnessId = String(payload.witnessId ?? "").trim();
+
+  const repo = getRepository();
+  const job = repo.createTaamAlignmentJob({ kind: "align", witnessId: witnessId || null, verseRange: verseId || null });
+  repo.updateTaamAlignmentJobStatus(job.id, "running");
+  try {
+    const verseIds = verseId
+      ? [verseId]
+      : witnessId
+        ? Array.from(new Set(repo.listRegionsByWitness(witnessId).flatMap((region) => [region.startVerseId, region.endVerseId]).filter(Boolean) as string[]))
+        : repo.listVerseIds();
+
+    const results = verseIds.map((id) => runTaamAlignmentForVerse(id, targetLayer));
+    repo.updateTaamAlignmentJobStatus(job.id, "completed");
+    return NextResponse.json({ ok: true, jobId: job.id, results });
+  } catch (error) {
+    repo.updateTaamAlignmentJobStatus(job.id, "failed", error instanceof Error ? error.message : "taam alignment failed");
+    return NextResponse.json({ error: error instanceof Error ? error.message : "Taam alignment failed." }, { status: 400 });
+  }
+}

--- a/apps/web/app/api/manuscripts/taamim/cascade/recompute/route.ts
+++ b/apps/web/app/api/manuscripts/taamim/cascade/recompute/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from "next/server";
+import { authErrorResponse, requireEditorUser } from "@/lib/authz";
+import { getRepository } from "@/lib/repository";
+import { recomputeTaamConsensusForVerse } from "@/lib/manuscripts-pipeline";
+
+export async function POST(request: Request) {
+  try {
+    await requireEditorUser();
+  } catch (error) {
+    return authErrorResponse(error) ?? NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const payload = (await request.json().catch(() => ({}))) as Record<string, unknown>;
+  const targetLayer = String(payload.targetLayer ?? "working_text");
+  const verseId = String(payload.verseId ?? "").trim();
+
+  const repo = getRepository();
+  const job = repo.createTaamAlignmentJob({ kind: "cascade", verseRange: verseId || null, witnessId: null });
+  repo.updateTaamAlignmentJobStatus(job.id, "running");
+  try {
+    const verseIds = verseId ? [verseId] : repo.listVerseIds();
+    const results = verseIds.map((id) => recomputeTaamConsensusForVerse(id, targetLayer));
+    repo.updateTaamAlignmentJobStatus(job.id, "completed");
+    return NextResponse.json({ ok: true, jobId: job.id, results });
+  } catch (error) {
+    repo.updateTaamAlignmentJobStatus(job.id, "failed", error instanceof Error ? error.message : "taam cascade failed");
+    return NextResponse.json({ error: error instanceof Error ? error.message : "Taam cascade failed." }, { status: 400 });
+  }
+}

--- a/apps/web/app/api/manuscripts/verse/[verseId]/taamim/apply-consensus/route.ts
+++ b/apps/web/app/api/manuscripts/verse/[verseId]/taamim/apply-consensus/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from "next/server";
+import { randomUUID } from "node:crypto";
+import { authErrorResponse, requireEditorUser } from "@/lib/authz";
+import { getRepository } from "@/lib/repository";
+
+export async function POST(_: Request, ctx: { params: Promise<{ verseId: string }> }) {
+  let username = "local-user";
+  try {
+    const user = await requireEditorUser();
+    username = user.username;
+  } catch (error) {
+    return authErrorResponse(error) ?? NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { verseId } = await ctx.params;
+  const repo = getRepository();
+  const consensus = repo.getWorkingTaamConsensus(verseId);
+  if (!consensus) {
+    return NextResponse.json({ error: "Consensus not found." }, { status: 404 });
+  }
+
+  const patchIds: string[] = [];
+  for (const mark of consensus.consensusTaam) {
+    const patch = repo.addPatch(
+      verseId as any,
+      {
+        type: "INSERT_TAAM",
+        taam: {
+          taamId: String(mark.taamId ?? randomUUID()),
+          name: String(mark.name ?? "ConsensusMark"),
+          unicodeMark: String(mark.unicodeMark ?? ""),
+          tier: (mark.tier as any) ?? "CONJUNCTIVE",
+          position: {
+            tokenIndex: Number((mark.position as any)?.tokenIndex ?? 0),
+            letterIndex: Number((mark.position as any)?.letterIndex ?? 0),
+          },
+          confidence: Number(mark.confidence ?? consensus.ensembleConfidence ?? 0.7),
+          reasons: Array.isArray((mark as any).reasons) ? (mark as any).reasons.map(String) : ["consensus-apply"],
+        },
+      },
+      "Applied OCR taam consensus",
+      username,
+      { sourceType: "import", sourceWitnessId: "consensus" },
+    );
+    patchIds.push(patch.id);
+  }
+
+  return NextResponse.json({ ok: true, verseId, patchIds, applied: patchIds.length });
+}

--- a/apps/web/app/api/manuscripts/verse/[verseId]/taamim/consensus/route.ts
+++ b/apps/web/app/api/manuscripts/verse/[verseId]/taamim/consensus/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from "next/server";
+import { getRepository } from "@/lib/repository";
+
+export async function GET(_: Request, ctx: { params: Promise<{ verseId: string }> }) {
+  const { verseId } = await ctx.params;
+  const repo = getRepository();
+  const consensus = repo.getWorkingTaamConsensus(verseId);
+  return NextResponse.json({ verseId, consensus });
+}

--- a/apps/web/app/api/manuscripts/verse/[verseId]/taamim/witnesses/route.ts
+++ b/apps/web/app/api/manuscripts/verse/[verseId]/taamim/witnesses/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from "next/server";
+import { getRepository } from "@/lib/repository";
+
+export async function GET(_: Request, ctx: { params: Promise<{ verseId: string }> }) {
+  const { verseId } = await ctx.params;
+  const repo = getRepository();
+  const rows = repo.listWitnessTaamAlignmentsForVerse(verseId, "working_text");
+  return NextResponse.json({ verseId, rows });
+}

--- a/apps/web/app/manuscripts/monitoring/page.tsx
+++ b/apps/web/app/manuscripts/monitoring/page.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+type SummaryPayload = {
+  generatedAt: string;
+  witnesses: Array<{
+    witnessId: string;
+    witnessName: string;
+    sourcePriority: number | null;
+    ingestStatus: string;
+    ocrStatus: string;
+    splitStatus: string;
+    confidenceStatus: string;
+    pagesImported: number;
+    regionsTagged: number;
+    splitRows: number;
+    splitPartialRows: number;
+    ocrJobsFailed: number;
+    rssMb: number;
+    cpuPct: number;
+    queueDepth: number;
+    throttleState: string;
+  }>;
+  queues: {
+    textLowConfidence: number;
+    textDisagreement: number;
+    textUnavailablePartial: number;
+    remapAmbiguous: number;
+  };
+  jobs: {
+    taamQueued: number;
+    taamRunning: number;
+    taamFailed: number;
+    taamCompleted: number;
+  };
+};
+
+type JobsPayload = {
+  ocr: Array<{ id: string; regionId: string; status: string; attempts: number; error?: string; createdAt: string }>;
+  taam: Array<{ id: string; kind: string; status: string; attempts: number; error?: string; createdAt: string }>;
+};
+
+export default function ManuscriptsMonitoringPage() {
+  const [summary, setSummary] = useState<SummaryPayload | null>(null);
+  const [jobs, setJobs] = useState<JobsPayload | null>(null);
+  const [system, setSystem] = useState<any>(null);
+  const [paused, setPaused] = useState(false);
+  const [error, setError] = useState("");
+
+  async function refresh() {
+    try {
+      const [summaryRes, jobsRes, systemRes] = await Promise.all([
+        fetch("/api/manuscripts/monitoring/summary"),
+        fetch("/api/manuscripts/monitoring/jobs?limit=50"),
+        fetch("/api/manuscripts/monitoring/system"),
+      ]);
+      const summaryJson = (await summaryRes.json()) as SummaryPayload & { error?: string };
+      const jobsJson = (await jobsRes.json()) as JobsPayload & { error?: string };
+      const systemJson = (await systemRes.json()) as Record<string, unknown> & { error?: string };
+      if (!summaryRes.ok) throw new Error(summaryJson.error ?? "Failed to load monitoring summary.");
+      if (!jobsRes.ok) throw new Error(jobsJson.error ?? "Failed to load monitoring jobs.");
+      if (!systemRes.ok) throw new Error(systemJson.error ?? "Failed to load system telemetry.");
+      setSummary(summaryJson);
+      setJobs(jobsJson);
+      setSystem(systemJson);
+      setError("");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Monitoring refresh failed.");
+    }
+  }
+
+  useEffect(() => {
+    void refresh();
+  }, []);
+
+  useEffect(() => {
+    if (paused) return;
+    const timer = setInterval(() => void refresh(), 10_000);
+    return () => clearInterval(timer);
+  }, [paused]);
+
+  const alerts = useMemo(() => {
+    if (!summary) return [] as string[];
+    const items: string[] = [];
+    if (summary.queues.textLowConfidence > 0) items.push(`Low text confidence queue: ${summary.queues.textLowConfidence}`);
+    if (summary.queues.remapAmbiguous > 0) items.push(`Remap ambiguous queue: ${summary.queues.remapAmbiguous}`);
+    if (summary.jobs.taamFailed > 0) items.push(`Failed ta'am jobs: ${summary.jobs.taamFailed}`);
+    return items;
+  }, [summary]);
+
+  return (
+    <main className="reading-main">
+      <section className="panel">
+        <h2>Manuscripts Monitoring</h2>
+        <div className="reading-controls-row">
+          <button type="button" onClick={() => setPaused((value) => !value)}>{paused ? "Resume Auto-refresh" : "Pause Auto-refresh"}</button>
+          <button type="button" onClick={() => void refresh()}>Refresh now</button>
+          <span className="small">Cadence: 10s</span>
+        </div>
+        {error ? <p className="small" style={{ color: "#dc2626" }}>{error}</p> : null}
+      </section>
+
+      <section className="panel">
+        <h3>System</h3>
+        <div className="small">RSS: {Number((system?.telemetry as any)?.rssMb ?? 0).toFixed(1)} MB</div>
+        <div className="small">CPU: {Number((system?.telemetry as any)?.cpuPct ?? 0).toFixed(1)}%</div>
+        <div className="small">Throttle: {String((system?.telemetry as any)?.throttleState ?? "unknown")}</div>
+        <div className="small">
+          Worker limits: OCR {Number((system?.telemetry as any)?.limits?.ocrWorkers ?? 0)}, split/remap {Number((system?.telemetry as any)?.limits?.splitRemapWorkers ?? 0)}, ta'am {Number((system?.telemetry as any)?.limits?.taamAlignWorkers ?? 0)}
+        </div>
+      </section>
+
+      <section className="panel">
+        <h3>Queue Health</h3>
+        <div className="small">Low confidence: {summary?.queues.textLowConfidence ?? 0}</div>
+        <div className="small">Disagreement: {summary?.queues.textDisagreement ?? 0}</div>
+        <div className="small">Unavailable/partial: {summary?.queues.textUnavailablePartial ?? 0}</div>
+        <div className="small">Remap ambiguous: {summary?.queues.remapAmbiguous ?? 0}</div>
+      </section>
+
+      <section className="panel">
+        <h3>Alerts</h3>
+        {alerts.length === 0 ? <div className="small">No active alerts.</div> : alerts.map((alert) => <div className="small" key={alert}>{alert}</div>)}
+      </section>
+
+      <section className="panel">
+        <h3>Pipeline Status by Witness</h3>
+        <div className="small" style={{ overflowX: "auto" }}>
+          <table>
+            <thead>
+              <tr>
+                <th>Priority</th>
+                <th>Witness</th>
+                <th>Ingest</th>
+                <th>OCR</th>
+                <th>Split</th>
+                <th>Conf</th>
+                <th>Pages</th>
+                <th>Split Partial</th>
+                <th>OCR Failed</th>
+                <th>Throttle</th>
+              </tr>
+            </thead>
+            <tbody>
+              {(summary?.witnesses ?? []).map((w) => (
+                <tr key={w.witnessId}>
+                  <td>{w.sourcePriority ?? "-"}</td>
+                  <td>{w.witnessName}</td>
+                  <td>{w.ingestStatus}</td>
+                  <td>{w.ocrStatus}</td>
+                  <td>{w.splitStatus}</td>
+                  <td>{w.confidenceStatus}</td>
+                  <td>{w.pagesImported}</td>
+                  <td>{w.splitPartialRows}</td>
+                  <td>{w.ocrJobsFailed}</td>
+                  <td>{w.throttleState}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section className="panel">
+        <h3>Job Table</h3>
+        <div className="small">Ta'am jobs: queued {summary?.jobs.taamQueued ?? 0}, running {summary?.jobs.taamRunning ?? 0}, failed {summary?.jobs.taamFailed ?? 0}, completed {summary?.jobs.taamCompleted ?? 0}</div>
+        <h4>OCR Jobs</h4>
+        {(jobs?.ocr ?? []).slice(0, 20).map((job) => (
+          <div className="small" key={job.id}>{job.createdAt} | {job.status} | attempts {job.attempts} | {job.regionId}</div>
+        ))}
+        <h4>Ta'am Jobs</h4>
+        {(jobs?.taam ?? []).slice(0, 20).map((job) => (
+          <div className="small" key={job.id}>{job.createdAt} | {job.kind} | {job.status} | attempts {job.attempts}</div>
+        ))}
+      </section>
+    </main>
+  );
+}

--- a/apps/web/lib/manuscripts-import-runner.ts
+++ b/apps/web/lib/manuscripts-import-runner.ts
@@ -75,7 +75,7 @@ export function parseImportArgs(argv: string[]): ManuscriptImportArgs {
   }
 
   const startPage = Math.max(1, Number(get("--start-page") ?? 1));
-  const pageCountDefault = mode === "calibration" ? 20 : 100;
+  const pageCountDefault = mode === "calibration" ? 20 : 50;
   const pageCount = Math.max(1, Number(get("--page-count") ?? pageCountDefault));
 
   return {

--- a/apps/web/lib/manuscripts-pipeline.ts
+++ b/apps/web/lib/manuscripts-pipeline.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
-import { MANUSCRIPT_NORMALIZATION_FORM, compareVerseIdsCanonical, isVerseIdInRange } from "@targum/core";
+import { createHash } from "node:crypto";
+import { MANUSCRIPT_NORMALIZATION_FORM, compareVerseIdsCanonical, isHebrewLetter, isTaam, isVerseIdInRange } from "@targum/core";
 import { getDataPaths } from "./config";
 import { getRepository } from "./repository";
 import { createDeterministicCrop } from "./manuscripts-images";
@@ -340,4 +341,288 @@ export function recomputeCascadeForVerse(verseId: string, thresholds = { vatican
     reasonCodes: stored.reasonCodes,
     candidates: Array.from(byWitnessId.values()),
   };
+}
+
+function letterCount(text: string): number {
+  let count = 0;
+  for (const ch of text.normalize(MANUSCRIPT_NORMALIZATION_FORM)) {
+    if (isHebrewLetter(ch)) count += 1;
+  }
+  return count;
+}
+
+function extractWitnessTaam(text: string): Array<{ mark: string; witnessLetterOrdinal: number }> {
+  const out: Array<{ mark: string; witnessLetterOrdinal: number }> = [];
+  let lettersSeen = 0;
+  for (const ch of text.normalize(MANUSCRIPT_NORMALIZATION_FORM)) {
+    if (isHebrewLetter(ch)) {
+      lettersSeen += 1;
+      continue;
+    }
+    if (isTaam(ch) && lettersSeen > 0) {
+      out.push({ mark: ch, witnessLetterOrdinal: lettersSeen - 1 });
+    }
+  }
+  return out;
+}
+
+function mapLetterOrdinalToTokenPosition(verseId: string, targetOrdinal: number): { tokenIndex: number; letterIndex: number } {
+  const repo = getRepository();
+  const record = repo.getVerseRecord(verseId as any);
+  if (!record || record.verse.aramaicTokens.length === 0) return { tokenIndex: 0, letterIndex: 0 };
+  let cursor = 0;
+  for (let t = 0; t < record.verse.aramaicTokens.length; t += 1) {
+    const token = record.verse.aramaicTokens[t];
+    for (let l = 0; l < token.letters.length; l += 1) {
+      if (cursor >= targetOrdinal) return { tokenIndex: t, letterIndex: l };
+      cursor += 1;
+    }
+  }
+  const lastToken = record.verse.aramaicTokens.length - 1;
+  const lastLetter = Math.max(0, record.verse.aramaicTokens[lastToken]?.letters.length - 1);
+  return { tokenIndex: lastToken, letterIndex: lastLetter };
+}
+
+function hashText(text: string): string {
+  return createHash("sha1").update(text).digest("hex").slice(0, 12);
+}
+
+export function getSystemTelemetry(queueDepth = 0): {
+  rssMb: number;
+  cpuPct: number;
+  queueDepth: number;
+  throttleState: "normal" | "reduced" | "single";
+  limits: { ocrWorkers: number; splitRemapWorkers: number; taamAlignWorkers: number; imageFallbackWorkers: number; globalHeavyCap: number };
+} {
+  const rssMb = process.memoryUsage().rss / (1024 * 1024);
+  const cpuPct = Math.min(100, Math.max(0, (process.cpuUsage().user + process.cpuUsage().system) / 10000));
+  const throttleState: "normal" | "reduced" | "single" = rssMb > 7000 ? "single" : rssMb > 6200 ? "reduced" : "normal";
+  const base = throttleState === "single" ? 1 : 2;
+  return {
+    rssMb,
+    cpuPct,
+    queueDepth,
+    throttleState,
+    limits: {
+      ocrWorkers: base,
+      splitRemapWorkers: base,
+      taamAlignWorkers: base,
+      imageFallbackWorkers: throttleState === "normal" ? 1 : 0,
+      globalHeavyCap: throttleState === "single" ? 1 : 3,
+    },
+  };
+}
+
+export async function remapWitnessRegionsBySnippet(input: {
+  witnessId: string;
+  minScore?: number;
+  minMargin?: number;
+  maxWindow?: number;
+}): Promise<{ witnessId: string; total: number; assigned: number; ambiguous: number; unassigned: number }> {
+  const repo = getRepository();
+  const minScore = input.minScore ?? 0.78;
+  const minMargin = input.minMargin ?? 0.08;
+  const maxWindow = input.maxWindow ?? 5;
+  const verseIds = repo.listVerseIds().sort(compareVerseIdsCanonical);
+  const baselineByVerse = new Map(verseIds.map((id) => [id, normalizeComparisonText(renderAramaicFromVerseId(id))]));
+  const regions = repo.listRegionsByWitness(input.witnessId);
+
+  let assigned = 0;
+  let ambiguous = 0;
+  let unassigned = 0;
+
+  for (const region of regions) {
+    const ocr = repo.getRegionOcrArtifact(region.id);
+    const ocrText = normalizeComparisonText(ocr?.textRaw ?? "");
+    if (!ocrText) {
+      unassigned += 1;
+      repo.upsertPageRegion({
+        id: region.id,
+        pageId: region.pageId,
+        regionIndex: region.regionIndex,
+        bbox: region.bbox,
+        startVerseId: region.startVerseId,
+        endVerseId: region.endVerseId,
+        remapMethod: "snippet-fuzzy-v1",
+        remapConfidence: 0,
+        remapCandidates: [],
+        remapReviewRequired: true,
+        status: region.status,
+        notes: `${region.notes} | remap: OCR_EMPTY`,
+      });
+      continue;
+    }
+
+    const ranked: Array<{ startVerseId: string; endVerseId: string; score: number }> = [];
+    for (let i = 0; i < verseIds.length; i += 1) {
+      let windowText = "";
+      for (let width = 1; width <= maxWindow && i + width - 1 < verseIds.length; width += 1) {
+        const currentVerseId = verseIds[i + width - 1];
+        windowText = `${windowText} ${baselineByVerse.get(currentVerseId) ?? ""}`.trim();
+        const score = alignWitnessToBaseline(ocrText, windowText).matchScore;
+        ranked.push({ startVerseId: verseIds[i], endVerseId: currentVerseId, score });
+      }
+    }
+    ranked.sort((a, b) => b.score - a.score);
+    const top = ranked[0];
+    const second = ranked[1];
+    const shouldAssign = Boolean(top) && top.score >= minScore && (top.score - (second?.score ?? 0)) >= minMargin;
+    if (!top) {
+      unassigned += 1;
+      continue;
+    }
+
+    if (shouldAssign) {
+      assigned += 1;
+    } else {
+      ambiguous += 1;
+    }
+
+    repo.upsertPageRegion({
+      id: region.id,
+      pageId: region.pageId,
+      regionIndex: region.regionIndex,
+      bbox: region.bbox,
+      startVerseId: shouldAssign ? top.startVerseId : region.startVerseId,
+      endVerseId: shouldAssign ? top.endVerseId : region.endVerseId,
+      remapMethod: "snippet-fuzzy-v1",
+      remapConfidence: top.score,
+      remapCandidates: ranked.slice(0, 3),
+      remapReviewRequired: !shouldAssign,
+      status: region.status,
+      notes: `${region.notes} | remap: ${shouldAssign ? "auto-assigned" : "review-required"}`,
+    });
+  }
+
+  return {
+    witnessId: input.witnessId,
+    total: regions.length,
+    assigned,
+    ambiguous,
+    unassigned,
+  };
+}
+
+export async function backfillWitnessFromRemap(witnessId: string): Promise<{ witnessId: string; regions: number; versesTouched: number }> {
+  const repo = getRepository();
+  const regions = repo
+    .listRegionsByWitness(witnessId)
+    .filter((r) => r.startVerseId && r.endVerseId)
+    .filter((r) => !r.remapReviewRequired);
+
+  const touched = new Set<string>();
+  for (const region of regions) {
+    const result = await splitRegionIntoWitnessVerses(region.id);
+    for (const verseId of result.verseIds) {
+      touched.add(verseId);
+      recomputeSourceConfidence(verseId);
+      recomputeCascadeForVerse(verseId);
+    }
+  }
+  return { witnessId, regions: regions.length, versesTouched: touched.size };
+}
+
+export function runTaamAlignmentForVerse(verseId: string, targetLayer = "working_text"): {
+  verseId: string;
+  targetLayer: string;
+  targetTextHash: string;
+  alignedWitnesses: number;
+} {
+  const repo = getRepository();
+  const witnesses = repo.listWitnessVersesForVerse(verseId);
+  const working = repo.getWorkingVerseText(verseId);
+  const targetText = normalizeComparisonText(working?.selectedTextNormalized || working?.selectedTextSurface || renderAramaicFromVerseId(verseId));
+  const targetLetters = Math.max(1, letterCount(targetText));
+  const targetTextHash = hashText(targetText);
+
+  let alignedWitnesses = 0;
+  for (const witness of witnesses) {
+    const witnessText = normalizeComparisonText(witness.textNormalized || witness.textRaw);
+    const witnessLetters = Math.max(1, letterCount(witnessText));
+    const extracted = extractWitnessTaam(witness.textRaw || witness.textNormalized);
+    const aligned = extracted.map((entry, idx) => {
+      const mappedOrdinal = Math.round((entry.witnessLetterOrdinal / witnessLetters) * (targetLetters - 1));
+      const position = mapLetterOrdinalToTokenPosition(verseId, mappedOrdinal);
+      return {
+        taamId: `${witness.witnessId}:${verseId}:${idx}`,
+        name: `OCR_${entry.mark.codePointAt(0)?.toString(16) ?? "mark"}`,
+        unicodeMark: entry.mark,
+        tier: "CONJUNCTIVE",
+        position,
+        confidence: Math.max(0.2, Math.min(0.95, witness.sourceConfidence * 0.9)),
+        sourceWitnessId: witness.witnessId,
+      };
+    });
+
+    repo.upsertWitnessTaamAlignment({
+      verseId,
+      witnessId: witness.witnessId,
+      targetLayer,
+      targetTextHash,
+      taam: aligned,
+      metrics: {
+        extractedCount: extracted.length,
+        alignedCount: aligned.length,
+        witnessLetters,
+        targetLetters,
+      },
+      status: aligned.length > 0 ? "ok" : "partial",
+    });
+    alignedWitnesses += 1;
+  }
+
+  return { verseId, targetLayer, targetTextHash, alignedWitnesses };
+}
+
+export function recomputeTaamConsensusForVerse(verseId: string, targetLayer = "working_text"): {
+  verseId: string;
+  targetLayer: string;
+  consensusCount: number;
+  ensembleConfidence: number;
+  flags: string[];
+} {
+  const repo = getRepository();
+  const working = repo.getWorkingVerseText(verseId);
+  const targetText = normalizeComparisonText(working?.selectedTextNormalized || working?.selectedTextSurface || renderAramaicFromVerseId(verseId));
+  const targetTextHash = hashText(targetText);
+  const alignments = repo.listWitnessTaamAlignmentsForVerse(verseId, targetLayer).filter((row) => row.targetTextHash === targetTextHash);
+
+  const bucket = new Map<string, { weight: number; sample: Record<string, unknown> }>();
+  for (const alignment of alignments) {
+    const witness = repo.getWitnessVerse(verseId, alignment.witnessId);
+    const weight = witness?.sourceConfidence ?? 0.2;
+    for (const mark of alignment.taam) {
+      const pos = (mark.position ?? {}) as { tokenIndex?: number; letterIndex?: number };
+      const key = `${pos.tokenIndex ?? 0}:${pos.letterIndex ?? 0}:${String(mark.unicodeMark ?? "")}`;
+      const current = bucket.get(key);
+      if (current) current.weight += weight;
+      else bucket.set(key, { weight, sample: mark });
+    }
+  }
+
+  const ranked = Array.from(bucket.values()).sort((a, b) => b.weight - a.weight);
+  const totalWeight = ranked.reduce((sum, item) => sum + item.weight, 0) || 1;
+  const consensus = ranked.slice(0, 128).map((item) => ({
+    ...item.sample,
+    confidence: Math.max(0.2, Math.min(0.99, item.weight / totalWeight)),
+    reasons: ["consensus-vote"],
+  }));
+  const ensembleConfidence = consensus.length > 0 ? Math.min(0.99, ranked[0]?.weight / totalWeight + 0.35) : 0.2;
+  const flags: string[] = [];
+  if (consensus.length === 0) flags.push("MISSING_TAAM_SIGNAL");
+  if (ranked.length > consensus.length + 20) flags.push("TAAM_DISAGREEMENT");
+  if (ensembleConfidence < 0.65) flags.push("LOW_TAAM_CONFIDENCE");
+  const reasonCodes = flags.length > 0 ? flags.map((flag) => `${flag}_AUTO`) : ["CONSENSUS_OK"];
+
+  repo.upsertWorkingTaamConsensus({
+    verseId,
+    targetLayer,
+    targetTextHash,
+    consensusTaam: consensus,
+    ensembleConfidence,
+    flags,
+    reasonCodes,
+  });
+
+  return { verseId, targetLayer, consensusCount: consensus.length, ensembleConfidence, flags };
 }

--- a/docs/m1-8gb-runtime-profile.md
+++ b/docs/m1-8gb-runtime-profile.md
@@ -1,0 +1,32 @@
+# M1 Mac Mini 8GB Runtime Profile
+
+Target host: dedicated Apple Silicon M1 Mac Mini with 8GB RAM.
+
+## Defaults
+- Batch size: 50 pages per witness run.
+- OCR workers: 2 max.
+- Split/remap workers: 2 max.
+- Ta'am alignment workers: 2 max.
+- Image fallback workers: 1 max.
+- Global heavy job cap: 3.
+
+## Adaptive Throttling
+- `reduced` mode when RSS > 6200 MB:
+  - heavy workers reduced to 1
+  - image fallback paused
+- `single` mode when RSS > 7000 MB:
+  - one heavy job at a time
+  - emit monitoring alert
+- return to `normal` only after sustained memory recovery.
+
+## Monitoring Surface
+Use `/manuscripts/monitoring` and these APIs:
+- `GET /api/manuscripts/monitoring/summary`
+- `GET /api/manuscripts/monitoring/jobs`
+- `GET /api/manuscripts/monitoring/system`
+
+Telemetry fields persisted in run state:
+- `rss_mb`
+- `cpu_pct`
+- `queue_depth`
+- `throttle_state`

--- a/docs/manuscript-operations-playbook.md
+++ b/docs/manuscript-operations-playbook.md
@@ -33,7 +33,7 @@
   - `decision=<Verified|Keep baseline|Accept witness>;reason=<short reason>;page=<index>;region=<id>`
 
 ## 4) Scale-Up Batch + Failure Handling
-- Batch size: 100 pages per witness per run.
+- Batch size: 50 pages per witness per run on the dedicated M1 Mac Mini (8GB RAM).
 - Stop batch if either condition is met:
   - OCR job failure rate > 15%
   - split partial-rate > 30%
@@ -54,3 +54,12 @@
 - Blockers:
   - unresolved priority gate blockers
   - unresolved data quality blockers
+
+## 6) Monitoring Page
+- Use `/manuscripts/monitoring` for live operations oversight.
+- Refresh cadence: 10s (pause/resume available in UI).
+- Track:
+  - per-witness stage status
+  - queue health (`low_confidence`, `disagreement`, `unavailable_partial`, remap ambiguous)
+  - OCR and ta'am alignment job states
+  - system telemetry (`rss_mb`, `cpu_pct`, `queue_depth`, `throttle_state`)

--- a/planning.md
+++ b/planning.md
@@ -193,3 +193,13 @@ If not provided, build tools/UI to capture mapping iteratively.
 - Required status checks: `quality-checks`, `validate-pr-body`.
 - Strict required status checks and admin enforcement are enabled.
 - Verification record: `docs/branch-protection-verification-2026-02-20.md`.
+
+## Implementation Update (2026-02-23)
+- Added OCR snippet-based remap flow for out-of-order witness pages/regions with conservative confidence+margin policy.
+- Added remap metadata persistence on `page_regions` for audit/review workflows.
+- Added ta'am witness-alignment storage + working consensus storage and corresponding APIs.
+- Added `/manuscripts/monitoring` page and monitoring APIs for summary/jobs/system telemetry.
+- Added M1 Mac Mini (8GB) runtime tuning defaults:
+  - batch default 50 pages
+  - runtime telemetry fields in run-state (`rss_mb`, `cpu_pct`, `queue_depth`, `throttle_state`)
+  - throttling profile (`normal` -> `reduced` -> `single`) based on RSS thresholds.

--- a/todo.md
+++ b/todo.md
@@ -124,3 +124,13 @@ Status date: 2026-02-20
 
 ## Open Items (Remaining)
 - [x] Run and document the initial real 10-20 page calibration pass with actual manuscript assets (implemented from local `/book_sources` PDFs).
+
+## TODO 10: Snippet Remap + Ta'am Alignment + Monitoring
+- [x] Add OCR snippet-based region remap API with conservative auto-assign + review fallback
+- [x] Add remap metadata persistence on regions (`method`, `confidence`, `candidates`, `review_required`)
+- [x] Add split/confidence/cascade backfill helper for remapped regions
+- [x] Add witness ta'am alignment persistence + consensus persistence tables
+- [x] Add ta'am alignment/cascade/apply APIs
+- [x] Add manuscripts monitoring APIs (`summary`, `jobs`, `system`)
+- [x] Add `/manuscripts/monitoring` page with auto-refresh controls and alert cards
+- [x] Add M1 Mac Mini (8GB) runtime tuning defaults (batch size and throttling telemetry)


### PR DESCRIPTION
## Summary
- add OCR snippet-based remap with conservative assignment/review fallback
- add ta'am alignment + consensus persistence and APIs
- add monitoring dashboard page + monitoring APIs
- add M1 8GB runtime profile docs and batch tuning

## Acceptance Criteria Checklist
- [x] Remap API added with conservative threshold/margin handling
- [x] Ta'am alignment and consensus APIs added
- [x] Monitoring APIs and UI page added
- [x] Storage schema supports remap metadata + ta'am alignment tables + telemetry fields

## Migration / Data Notes
- Additive schema changes are handled in repository init migrations.
- Existing rows default safely for new columns (`remap_method`, `remap_confidence`, telemetry fields).
- No destructive migration performed.

## Test Evidence
- `pnpm typecheck`
- `pnpm test`
- `pnpm --filter web build`
